### PR TITLE
fix issue #43: added enhanced-overriden-template

### DIFF
--- a/lib/hiptest-publisher/options_parser.rb
+++ b/lib/hiptest-publisher/options_parser.rb
@@ -310,9 +310,16 @@ class TemplateFinder
 
   def dirs
     @dirs ||= begin
-      search_dirs = template_dirs.map { |path|
-        "#{hiptest_publisher_path}/lib/templates/#{path}"
+      search_dirs = []
+      #Template paths in overriden_templates
+      template_dirs.map { |path|
+        search_dirs.push("#{overriden_templates}/#{path}") if overriden_templates
       }
+      #Template paths in hiptest_publisher
+      template_dirs.map { |path|
+        search_dirs.push("#{hiptest_publisher_path}/lib/templates/#{path}")
+      }
+      # for backwards compatibility
       search_dirs.unshift(overriden_templates) if overriden_templates
       search_dirs
     end


### PR DESCRIPTION
This change should be backwards compatible.  It allows a someone overriding the templates to use the same directory structure that hip test does.  It allows for use of different actionwords.hbs in different context (step_defintions vs actionwords).

The only issue I found which may or may not be an easy of use design flaw is that in my use case I needed to copy the original cucumber/java/actionwords.hbs into my override folder because the wrong template was being picked up.  This is not caused by my change but by the search path design.